### PR TITLE
add missing space

### DIFF
--- a/_sources/apidoc/owl_nlp_tfidf.rst.txt
+++ b/_sources/apidoc/owl_nlp_tfidf.rst.txt
@@ -125,7 +125,7 @@ Get the file handle associated with TFIDF model.
 
   val doc_count : Owl_nlp_vocabulary.t -> string -> float array * int
 
-``doc_count vocab fname``count occurrency in all documents contained in the raw text corpus of file ``fname``, for all words
+``doc_count vocab fname`` count occurrency in all documents contained in the raw text corpus of file ``fname``, for all words
 
 `source code <https://github.com/ryanrhymes/owl/blob/master/src/owl/nlp/owl_nlp_tfidf.ml#L89>`__
 


### PR DESCRIPTION
Without the space this renders wrong:

![image](https://user-images.githubusercontent.com/927609/65838010-8d32d480-e2fe-11e9-8e78-1e828f081bc7.png)
