### PR TITLE
Update two links that display wrongly in project/finished

### DIFF
--- a/_sources/project/finished.rst.txt
+++ b/_sources/project/finished.rst.txt
@@ -97,8 +97,8 @@ By `Ta-Chu Kao <https://github.com/tachukao>`_ and `Marcello Seri <https://githu
 
 Owl Ode is a lightweight package for solving ordinary differential equations. Built on top of Owl's numerical library, Owl Ode was designed with extensibility and ease of use in mind and includes a number of classic ode solvers (e.g. Euler and Runge-Kutta, in both adaptive and fixed-step variants) and symplectic sovlers (e.g. Leapfrog), with more to come.
 
-Taking full advantage of Owl's automatic differentiation library, we plan on supporting a number of fully differentiable solvers, which can be used, for example, for `training Neural Odes <https://github.com/tachukao/adjoint_ode/>`.
+Taking full advantage of Owl's automatic differentiation library, we plan on supporting a number of fully differentiable solvers, which can be used, for example, for `training Neural Odes <https://github.com/tachukao/adjoint_ode/>`_.
 
-Currently, Owl Ode includes separately-released thin wrappers around Sundials Cvode (via sundialsml's own wrapper) and ODEPACK, native ocaml `contact variational integrators <https://github.com/mseri/ocaml-cviode>`, and exposes a fully native ocaml module compatible with js_of_ocaml (owl-ode-base).
+Currently, Owl Ode includes separately-released thin wrappers around Sundials Cvode (via sundialsml's own wrapper) and ODEPACK, native ocaml `contact variational integrators <https://github.com/mseri/ocaml-cviode>`_, and exposes a fully native ocaml module compatible with js_of_ocaml (owl-ode-base).
 
 Going forward, we aim to expose more functions in Sundials, make the API even more flexible and configurable, and provide bindings for other battle-tested ODE solvers.


### PR DESCRIPTION
[This page](https://ocaml.xyz/project/finished.html) on the home-page of ocaml.xyz showed this, with no clickable links on the two links:

> Taking full advantage of Owl’s automatic differentiation library, we plan on supporting a number of fully differentiable solvers, which can be used, for example, for training Neural Odes <https://github.com/tachukao/adjoint_ode/>.
>
> Currently, Owl Ode includes separately-released thin wrappers around Sundials Cvode (via sundialsml’s own wrapper) and ODEPACK, native ocaml contact variational integrators <https://github.com/mseri/ocaml-cviode>, and exposes a fully native ocaml module compatible with js_of_ocaml (owl-ode-base).

My tiny pull-request fixes this issue.