### PR TITLE
Scrollable Navbar

### DIFF
--- a/_static/basic.css
+++ b/_static/basic.css
@@ -54,7 +54,10 @@ div.sphinxsidebar {
     font-size: 90%;
     word-wrap: break-word;
     overflow-wrap : break-word;
+	overflow-y: scroll;
+	height: 90%;
 }
+
 
 div.sphinxsidebar ul {
     list-style: none;

--- a/_static/basic.css
+++ b/_static/basic.css
@@ -56,6 +56,14 @@ div.sphinxsidebar {
     overflow-wrap : break-word;
 	overflow-y: scroll;
 	height: 90%;
+	/*-- Hide scrollbar on Firefox, IE --*/
+	-ms-overflow-style: none;
+	scrollbar-width: none
+}
+
+/*-- Hide scrollbar on Chrome, Safari, Opera --*/
+div.sphinxsidebar::-webkit-scrollbar {
+	display: none;
 }
 
 


### PR DESCRIPTION
The navigation bar hides the overflowing contents, making the last few items inaccessible. 
For instance, see [Proposed Sub-Projects](https://ocaml.xyz/project/proposal.html), [Finished Sub-Projects](https://ocaml.xyz/project/finished.html).

I have added vertical scrolling to the navbar in this pull request. I have also chosen to keep the scrollbar hidden to make it less cluttered. Please let me know if you'd like to see this changed.
